### PR TITLE
Add step to change directory to project directory

### DIFF
--- a/app/ActionsOnInstall/ChangeDirectory.php
+++ b/app/ActionsOnInstall/ChangeDirectory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\ActionsOnInstall;
+
+use App\Support\BaseAction;
+
+class ChangeDirectory extends BaseAction
+{
+    /**
+     * Change the working directory to the project directory.
+     *
+     * @return void
+     */
+    public function __invoke(): void
+    {
+        $changeDirectory = base_path('change-directory.sh');
+        $directory = config('lambo.store.project_path');
+
+        shell_exec("$changeDirectory $directory");
+    }
+}

--- a/app/Commands/NewCommand.php
+++ b/app/Commands/NewCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\ActionsOnInstall\ChangeDirectory;
 use App\ActionsOnInstall\CreateDatabase;
 use App\ActionsOnInstall\CreateNewApplication;
 use App\ActionsOnInstall\InitializeGit;
@@ -25,7 +26,7 @@ class NewCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'new 
+    protected $signature = 'new
         {projectName : Name of the Laravel project}
         {--c|custom : Customise config options.}
         {--dev : Choose the dev branch instead of master.}
@@ -100,6 +101,7 @@ class NewCommand extends Command
         $this->action(ValetLink::class);
         $this->action(OpenBrowser::class);
         $this->action(OpenEditor::class);
+        $this->action(ChangeDirectory::class);
     }
 
     /**

--- a/change-directory.sh
+++ b/change-directory.sh
@@ -1,0 +1,2 @@
+cd "$1"
+exec "$SHELL"


### PR DESCRIPTION
This PR adds an action to be run as a final step on install to change the working directory to the project directory.  There is a new `ChangeDirectory` action that passes the project directory as an argument to a `change-directory.sh` shell script.  Since this action runs as the final step, there is no need to make any changes to the earlier actions.